### PR TITLE
flesh out authentication via envvar; spell-check

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -45,12 +45,14 @@ library("gistr")
 
 There are two ways to authorise gistr to work with your GitHub account:
 
-* Generate a personal access token (PAT) at [https://help.github.com/articles/creating-an-access-token-for-command-line-use](https://help.github.com/articles/creating-an-access-token-for-command-line-use) and record it in the `GITHUB_PAT` envar.
+* Generate a personal access token (PAT) at [https://help.github.com/articles/creating-an-access-token-for-command-line-use](https://help.github.com/articles/creating-an-access-token-for-command-line-use) and record it in the `GITHUB_PAT` environment variable.
+  - To test out this approach, execute this in R: `Sys.setenv(GITHUB_PAT = "blahblahblah")`, where "blahblahblah" is the PAT you got from GitHub. Then take `gistr` out for a test drive.
+  - If that works, you will probably want to define the GITHUB_PAT environment variable in a file such as `~/.bash_profile` or `~/.Renviron`.
 * Interactively login into your GitHub account and authorise with OAuth.
 
 Using the PAT is recommended.
 
-Using the `gist_auth()` function you can authenticate seperately first, or if you're not authenticated, this function will run internally with each functionn call. If you have a PAT, that will be used, if not, OAuth will be used.
+Using the `gist_auth()` function you can authenticate separately first, or if you're not authenticated, this function will run internally with each function call. If you have a PAT, that will be used, if not, OAuth will be used.
 
 ```{r eval=FALSE}
 gist_auth()
@@ -58,7 +60,7 @@ gist_auth()
 
 ### Workflow
 
-In `gistr` you can use pipes, introduced perhaps first in R in the package `magrittr`, to pass outputs from one function to another. If you have used `dplyr` with pipes you can see the difference, and perhaps the utility, of this workflow over the traditional workflow in R. You can use a non-piping or a piping workflow with `gistr`. Examples below use a mix of both workflows. Here is an example of a piping wofklow (with some explanation):
+In `gistr` you can use pipes, introduced perhaps first in R in the package `magrittr`, to pass outputs from one function to another. If you have used `dplyr` with pipes you can see the difference, and perhaps the utility, of this workflow over the traditional workflow in R. You can use a non-piping or a piping workflow with `gistr`. Examples below use a mix of both workflows. Here is an example of a piping workflow (with some explanation):
 
 ```{r eval=FALSE}
 gists(what = "minepublic")[[1]] %>% # List my public gists, and index to get just the 1st one
@@ -85,7 +87,6 @@ update(add_files(gists(what = "minepublic")[[1]], "~/alm_othersources.md"))
 ```{r}
 rate_limit()
 ```
-
 
 ### List gists
 


### PR DESCRIPTION
I can't re-compile README.Rmd because the files `~/alm_othersources.md` and `~/stuff.md` don't exist on my system. Maybe those should be files within the package/repo that then get Rbuildignored?