### PR TITLE
adds GHE capability to gist_create_git(), fixes #75

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,8 +29,7 @@ Imports:
     assertthat,
     knitr,
     rmarkdown,
-    dplyr,
-    rlang
+    dplyr
 Suggests:
     git2r,
     testthat

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,8 @@ Imports:
     assertthat,
     knitr,
     rmarkdown,
-    dplyr
+    dplyr,
+    rlang
 Suggests:
     git2r,
     testthat

--- a/R/gist.R
+++ b/R/gist.R
@@ -5,10 +5,10 @@
 #' @param revision (character) A sha. optional
 #' @param x Object to coerce. Can be an integer (gist id), string
 #'   (gist id), a gist, or an list that can be coerced to a gist.
-#' @param url_api (character) Base endpoint for GitHub API, defaults to 
+#' @param host (character) Base endpoint for GitHub API, defaults to 
 #' \code{"https://api.github.com"}. Useful to specify with GitHub Enterprise,
-#' e.g. \code{"https://github.acme.com/api/v3"}.
-#' @param env_auth (character) Name of environment variable that contains
+#' e.g. \code{"https://github.hostname.com/api/v3"}.
+#' @param env_pat (character) Name of environment variable that contains
 #' a GitHub PAT (Personal Access Token), defaults to \code{"GITHUB_PAT"}.
 #' Useful to specify with GitHub Enterprise, e.g. \code{"GITHUB_ACME_PAT"}.
 #' @template all
@@ -56,14 +56,9 @@
 #' # httr::GET(url)
 #' }
 
-gist <- function(id, revision = NULL, url_api = NULL, env_auth = NULL, ...){
-  url <- switch_url('id', normalize_id(id), url_api)
-  if (is.null(env_auth)){
-    auth <- gist_auth()
-  } else {
-    pat <- Sys.getenv(env_auth, "")
-    auth <- httr::add_headers(Authorization = paste0("token ", pat)) 
-  }
+gist <- function(id, revision = NULL, host = NULL, env_pat = NULL, ...){
+  url <- switch_url('id', normalize_id(id), host)
+  auth <- gist_auth(env_pat = env_pat)
   if (!is.null(revision)) url <- file.path(url, revision)
   res <- gist_GET(url, auth, ghead(), ...)
   as.gist(res)

--- a/R/gist.R
+++ b/R/gist.R
@@ -57,11 +57,11 @@
 #' }
 
 gist <- function(id, revision = NULL, host = NULL, env_pat = NULL, ...){
-  # arguments used for GitHub Enterprise (GHE)
-  # host:    GHE api endpoint, e.g. "https://github.acme.com/api/v3"
-  #          (handled in switch_url -> ghbase)
-  # env_pat: name of environment variable to find PAT for GHE 
-  #          (handled in gist_auth)
+  # arguments used for GitHub Enterprise
+  # host:      api endpoint, e.g. "https://github.acme.com/api/v3"
+  #            (set eventually in ghbase)
+  # env_pat:   environment variable for PAT, e.g. "GITHUB_ACME_PAT"
+  #            (set in gist_auth)
   url <- switch_url('id', normalize_id(id), host = host)
   if (!is.null(revision)) url <- file.path(url, revision)
   res <- gist_GET(url, gist_auth(env_pat = env_pat), ghead(), ...)

--- a/R/gist.R
+++ b/R/gist.R
@@ -58,9 +58,8 @@
 
 gist <- function(id, revision = NULL, host = NULL, env_pat = NULL, ...){
   url <- switch_url('id', normalize_id(id), host)
-  auth <- gist_auth(env_pat = env_pat)
   if (!is.null(revision)) url <- file.path(url, revision)
-  res <- gist_GET(url, auth, ghead(), ...)
+  res <- gist_GET(url, gist_auth(env_pat = env_pat), ghead(), ...)
   as.gist(res)
 }
 

--- a/R/gist.R
+++ b/R/gist.R
@@ -7,7 +7,7 @@
 #'   (gist id), a gist, or an list that can be coerced to a gist.
 #' @param host (character) Base endpoint for GitHub API, defaults to 
 #' \code{"https://api.github.com"}. Useful to specify with GitHub Enterprise,
-#' e.g. \code{"https://github.hostname.com/api/v3"}.
+#' e.g. \code{"https://github.acme.com/api/v3"}.
 #' @param env_pat (character) Name of environment variable that contains
 #' a GitHub PAT (Personal Access Token), defaults to \code{"GITHUB_PAT"}.
 #' Useful to specify with GitHub Enterprise, e.g. \code{"GITHUB_ACME_PAT"}.

--- a/R/gist.R
+++ b/R/gist.R
@@ -5,6 +5,12 @@
 #' @param revision (character) A sha. optional
 #' @param x Object to coerce. Can be an integer (gist id), string
 #'   (gist id), a gist, or an list that can be coerced to a gist.
+#' @param url_api (character) Base endpoint for GitHub API, defaults to 
+#' \code{"https://api.github.com"}. Useful to specify with GitHub Enterprise,
+#' e.g. \code{"https://github.acme.com/api/v3"}.
+#' @param env_auth (character) Name of environment variable that contains
+#' a GitHub PAT (Personal Access Token), defaults to \code{"GITHUB_PAT"}.
+#' Useful to specify with GitHub Enterprise, e.g. \code{"GITHUB_ACME_PAT"}.
 #' @template all
 #' @details If a file is larger than ~1 MB, the content of the file given back 
 #' is truncated, so you won't get the entire contents. In the return S3 object
@@ -50,10 +56,16 @@
 #' # httr::GET(url)
 #' }
 
-gist <- function(id, revision = NULL, ...){
-  url <- switch_url('id', normalize_id(id))
+gist <- function(id, revision = NULL, url_api = NULL, env_auth = NULL, ...){
+  url <- switch_url('id', normalize_id(id), url_api)
+  if (is.null(env_auth)){
+    auth <- gist_auth()
+  } else {
+    pat <- Sys.getenv(env_auth, "")
+    auth <- httr::add_headers(Authorization = paste0("token ", pat)) 
+  }
   if (!is.null(revision)) url <- file.path(url, revision)
-  res <- gist_GET(url, gist_auth(), ghead(), ...)
+  res <- gist_GET(url, auth, ghead(), ...)
   as.gist(res)
 }
 

--- a/R/gist.R
+++ b/R/gist.R
@@ -57,7 +57,12 @@
 #' }
 
 gist <- function(id, revision = NULL, host = NULL, env_pat = NULL, ...){
-  url <- switch_url('id', normalize_id(id), host)
+  # arguments used for GitHub Enterprise (GHE)
+  # host:    GHE api endpoint, e.g. "https://github.acme.com/api/v3"
+  #          (handled in switch_url -> ghbase)
+  # env_pat: name of environment variable to find PAT for GHE 
+  #          (handled in gist_auth)
+  url <- switch_url('id', normalize_id(id), host = host)
   if (!is.null(revision)) url <- file.path(url, revision)
   res <- gist_GET(url, gist_auth(env_pat = env_pat), ghead(), ...)
   as.gist(res)

--- a/R/gist_auth.R
+++ b/R/gist_auth.R
@@ -30,9 +30,8 @@ gist_auth <- function(app = gistr_app, reauth = FALSE, env_pat = NULL) {
     return(cache$auth_config)
   }
 
-  # argument used for GitHub Enterprise (GHE)
-  # env_pat: name of environment variable to find PAT for GHE 
-  #          (handled here)
+  # argument used for GitHub Enterprise
+  # env_pat:   environment variable for PAT, e.g. "GITHUB_ACME_PAT"
   env_pat <- env_pat %||% "GITHUB_PAT"
 
   pat <- Sys.getenv(env_pat, "")

--- a/R/gist_auth.R
+++ b/R/gist_auth.R
@@ -29,12 +29,12 @@ gist_auth <- function(app = gistr_app, reauth = FALSE, env_pat = NULL) {
   if (exists("auth_config", envir = cache) && !reauth) {
     return(cache$auth_config)
   }
-  
-  if (is.null(env_pat)) {
-    # using github.com
-    env_pat <- "GITHUB_PAT"
-  }
-  
+
+  # argument used for GitHub Enterprise (GHE)
+  # env_pat: name of environment variable to find PAT for GHE 
+  #          (handled here)
+  env_pat <- env_pat %||% "GITHUB_PAT"
+
   pat <- Sys.getenv(env_pat, "")
   if (!identical(pat, "")) {
     auth_config <- httr::add_headers(Authorization = paste0("token ", pat))

--- a/R/gist_auth.R
+++ b/R/gist_auth.R
@@ -17,16 +17,25 @@
 #' @param app An \code{\link[httr]{oauth_app}} for GitHub. The default uses an 
 #' application \code{gistr_oauth} created by Scott Chamberlain.
 #' @param reauth (logical) Force re-authorization?
+#' @param env_pat (character) Name of environment variable that contains
+#' a GitHub PAT (Personal Access Token), defaults to \code{"GITHUB_PAT"}.
+#' Useful to specify with GitHub Enterprise, e.g. \code{"GITHUB_ACME_PAT"}.
 #' @examples \dontrun{
 #' gist_auth()
 #' }
 
-gist_auth <- function(app = gistr_app, reauth = FALSE) {
+gist_auth <- function(app = gistr_app, reauth = FALSE, env_pat = NULL) {
  
   if (exists("auth_config", envir = cache) && !reauth) {
     return(cache$auth_config)
   }
-  pat <- Sys.getenv("GITHUB_PAT", "")
+  
+  is.null(env_pat) {
+    # using github.com
+    env_pat <- "GITHUB_PAT"
+  }
+  
+  pat <- Sys.getenv(env_pat, "")
   if (!identical(pat, "")) {
     auth_config <- httr::add_headers(Authorization = paste0("token ", pat))
   } else if (!interactive()) {

--- a/R/gist_auth.R
+++ b/R/gist_auth.R
@@ -30,7 +30,7 @@ gist_auth <- function(app = gistr_app, reauth = FALSE, env_pat = NULL) {
     return(cache$auth_config)
   }
   
-  is.null(env_pat) {
+  if (is.null(env_pat)) {
     # using github.com
     env_pat <- "GITHUB_PAT"
   }

--- a/R/gist_create_git.R
+++ b/R/gist_create_git.R
@@ -231,7 +231,6 @@ gist_create_git <- function(files = NULL, description = "", public = TRUE,
     }
   } else {
     cred <- git2r::cred_env("GITHUB_USERNAME", cred_env_auth)
-    print(cred)
     trypush <- tryCatch(git2r::push(git, "gistr", "refs/heads/master", 
                                     force = TRUE, credentials = cred),
                         error = function(e) e)

--- a/R/gist_create_git.R
+++ b/R/gist_create_git.R
@@ -8,6 +8,11 @@
 #' to only upload artifacts of certain file exensions. Default: \code{FALSE}
 #' @param git_method (character) One of ssh (default) or https. If a remote 
 #' already exists, we use that remote, and this parameter is ignored. 
+#' @param host (character) Name of GitHub host, defaults to
+#' \code{"gist.github.com"}. Useful to specify with GitHub Enterprise.
+#' @param env_auth (character) Name of environment variable that contains
+#' a GitHub PAT (Personal Access Token), defaults to \code{"GITHUB_PAT"}.
+#' Useful to specify with GitHub Enterprise. 
 #' @param sleep (integer) Seconds to sleep after creating gist, but before 
 #' collecting metadata on the gist. If uploading a lot of stuff, you may want to
 #' set this to a higher value, otherwise, you may not get accurate metadata for
@@ -125,7 +130,7 @@ gist_create_git <- function(files = NULL, description = "", public = TRUE,
   browse = TRUE, knit = FALSE, code = NULL, filename = "code.R",
   knitopts=list(), renderopts=list(), include_source = FALSE, 
   artifacts = FALSE, imgur_inject = FALSE, git_method = "ssh", 
-  sleep = 1, ...) {
+  host = NULL, env_auth = NULL, sleep = 1, ...) {
   
   if (!requireNamespace("git2r", quietly = TRUE)) {
     stop("Please install git2r", call. = FALSE)
@@ -133,6 +138,22 @@ gist_create_git <- function(files = NULL, description = "", public = TRUE,
   
   # pick git remote method
   git_method <- match.arg(git_method, c("ssh", "https"))
+  
+  # set host
+  if (is.null(host)) {
+    host <- "gist.github.com"
+  }
+  
+  # set env_auth
+  if (is.null(env_auth)) {
+    env_auth <- "GITHUB_PAT"
+  }
+
+  # validate host, env_auth
+  assertthat::assert_that(
+    assertthat::is.string(host), 
+    assertthat::is.string(env_auth)
+  )
   
   # code handler
   if (!is.null(code)) files <- code_handler(code, filename)

--- a/R/gist_create_git.R
+++ b/R/gist_create_git.R
@@ -295,22 +295,17 @@ unpack <- function(z) {
   }
 }
 
-cgist <- function(description, public, url_api = NULL, env_auth = NULL) {
+cgist <- function(description, public, host = NULL, env_pat = NULL) {
 
   # arguments used for GitHub Enterprise (GHE)
-  # url_api:  GHE api endpoint, e.g. "https://github.acme.com/api/v3"
-  # env_auth: name of environment variable to find PAT for GHE 
+  # host:  GHE api endpoint, e.g. "https://github.acme.com/api/v3"
+  # env_pat: name of environment variable to find PAT for GHE 
   
-  if (is.null(url_api)) {
-    url_api <- ghbase()
+  if (is.null(host)) {
+    host <- ghbase()
   } 
   
-  if (is.null(env_auth)) {
-    auth <- gist_auth()
-  } else {
-    pat <- Sys.getenv(env_auth, "")
-    auth <- httr::add_headers(Authorization = paste0("token ", pat)) 
-  }
+  auth <- gist_auth(env_pat = env_pat)
   
   res <- httr::POST(paste0(url_api, '/gists'), 
                     auth, 

--- a/R/gist_create_git.R
+++ b/R/gist_create_git.R
@@ -11,10 +11,6 @@
 #' @param host (character) Base endpoint for GitHub API, defaults to 
 #' \code{"https://api.github.com"}. Useful to specify with GitHub Enterprise,
 #' e.g. \code{"https://github.acme.com/api/v3"}.
-#' @param env_user (character) Name of environment variable that contains
-#' a GitHub user name, defaults to \code{"GITHUB_USERNAME"}. 
-#' Useful to specify with GitHub Enterprise, e.g. \code{"GITHUB_ACME_USERNAME"}.
-#' This is used only if \code{git_method} is \code{"https"}.
 #' @param env_pat (character) Name of environment variable that contains
 #' a GitHub PAT (Personal Access Token), defaults to \code{"GITHUB_PAT"}.
 #' Useful to specify with GitHub Enterprise, e.g. \code{"GITHUB_ACME_PAT"}.
@@ -139,7 +135,7 @@ gist_create_git <- function(files = NULL, description = "", public = TRUE,
   browse = TRUE, knit = FALSE, code = NULL, filename = "code.R",
   knitopts=list(), renderopts=list(), include_source = FALSE, 
   artifacts = FALSE, imgur_inject = FALSE, git_method = "ssh", 
-  host = NULL, env_user = NULL, env_pat = NULL, gist_host = NULL,
+  host = NULL, env_pat = NULL, gist_host = NULL,
   sleep = 1, ...) {
   
   if (!requireNamespace("git2r", quietly = TRUE)) {
@@ -149,10 +145,8 @@ gist_create_git <- function(files = NULL, description = "", public = TRUE,
   # arguments used for GitHub Enterprise
   # host:      api endpoint, e.g. "https://github.acme.com/api/v3"
   #            (set eventually in ghbase)
-  # env_user:  environment variable for username, e.g. "GITHUB_ACME_USER" 
   # env_pat:   environment variable for PAT, e.g. "GITHUB_ACME_PAT"
   # gist_host: name of host, e.g, "https://gist.github.acme.com"
-  env_user <- env_user %||% "GITHUB_USERNAME"
   env_pat <- env_pat %||% "GITHUB_PAT"
   
   # set gist_host
@@ -236,7 +230,7 @@ gist_create_git <- function(files = NULL, description = "", public = TRUE,
       git2r::push(git, "gistr", "refs/heads/master", force = TRUE)
     }
   } else {
-    cred <- git2r::cred_env(env_user, env_pat)
+    cred <- git2r::cred_token(env_pat)
     trypush <- tryCatch(git2r::push(git, "gistr", "refs/heads/master", 
                                     force = TRUE, credentials = cred),
                         error = function(e) e)

--- a/R/gist_create_git.R
+++ b/R/gist_create_git.R
@@ -10,7 +10,7 @@
 #' already exists, we use that remote, and this parameter is ignored. 
 #' @param host (character) Base endpoint for GitHub API, defaults to 
 #' \code{"https://api.github.com"}. Useful to specify with GitHub Enterprise,
-#' e.g. \code{"https://github.hostname.com/api/v3"}.
+#' e.g. \code{"https://github.acme.com/api/v3"}.
 #' @param env_user (character) Name of environment variable that contains
 #' a GitHub user name, defaults to \code{"GITHUB_USERNAME"}. 
 #' Useful to specify with GitHub Enterprise, e.g. \code{"GITHUB_ACME_USERNAME"}.
@@ -20,7 +20,7 @@
 #' Useful to specify with GitHub Enterprise, e.g. \code{"GITHUB_ACME_PAT"}.
 #' @param gist_host (character) Name of gist host, uses heuristics with
 #' \code{host} to default to \code{"gist.github.com"} or 
-#' \code{"gist.github.hostname.com"}. Override if these heuristics do not 
+#' \code{"gist.github.acme.com"}. Override if these heuristics do not 
 #' give the correct result.
 #' @param sleep (integer) Seconds to sleep after creating gist, but before 
 #' collecting metadata on the gist. If uploading a lot of stuff, you may want to
@@ -298,7 +298,7 @@ unpack <- function(z) {
 cgist <- function(description, public, host = NULL, env_pat = NULL) {
 
   # arguments used for GitHub Enterprise (GHE)
-  # host:  GHE api endpoint, e.g. "https://github.acme.com/api/v3"
+  # host:    GHE api endpoint, e.g. "https://github.acme.com/api/v3"
   # env_pat: name of environment variable to find PAT for GHE 
   
   if (is.null(host)) {

--- a/R/gist_create_git.R
+++ b/R/gist_create_git.R
@@ -302,13 +302,12 @@ cgist <- function(description, public, host = NULL, env_pat = NULL) {
   # env_pat: name of environment variable to find PAT for GHE 
   
   if (is.null(host)) {
+    # using github.com
     host <- ghbase()
   } 
   
-  auth <- gist_auth(env_pat = env_pat)
-  
   res <- httr::POST(paste0(host, '/gists'), 
-                    auth, 
+                    gist_auth(env_pat = env_pat), 
                     encode = "json",
                     body = jsonlite::toJSON(list(
                       description = description,

--- a/R/gist_create_git.R
+++ b/R/gist_create_git.R
@@ -146,23 +146,18 @@ gist_create_git <- function(files = NULL, description = "", public = TRUE,
     stop("Please install git2r", call. = FALSE)
   }
   
-  # pick git remote method
-  git_method <- match.arg(git_method, c("ssh", "https"))
-  
-  # arguments used for GitHub Enterprise (GHE)
-  # host:      GHE api endpoint, e.g. "https://github.acme.com/api/v3"
+  # arguments used for GitHub Enterprise
+  # host:      api endpoint, e.g. "https://github.acme.com/api/v3"
   #            (set eventually in ghbase)
-  # env_pat:   name of environment variable to find PAT for GHE 
+  # env_user:  environment variable for username, e.g. "GITHUB_ACME_USER" 
   #            (set here)
-  # env_user:  name of environment variable to find username for GHE
+  # env_pat:   environment variable for PAT, e.g. "GITHUB_ACME_PAT"
   #            (set here)
-  # gist_host: name of host
+  # gist_host: name of host, e.g, "https://gist.github.acme.com"
   #            (set here)
-  
   env_user <- env_user %||% "GITHUB_USERNAME"
   env_pat <- env_pat %||% "GITHUB_PAT"
   
-  # set gist host
   if (is.null(gist_host)) {
     if (identical(ghbase(host), ghbase())) {
       # using github.com
@@ -170,10 +165,13 @@ gist_create_git <- function(files = NULL, description = "", public = TRUE,
     } else {
       # use heuristics - extract hostname from url and prepend with "gist."
       hostname <- httr::parse_url(host)$hostname
-      gist_host <- paste0("gist.", hostname)
       message("Setting `gist_host` to \"", gist_host,"\".")
+      gist_host <- paste0("gist.", hostname)
     }
   }
+  
+  # pick git remote method
+  git_method <- match.arg(git_method, c("ssh", "https"))
   
   # code handler
   if (!is.null(code)) files <- code_handler(code, filename)
@@ -292,12 +290,11 @@ unpack <- function(z) {
 
 cgist <- function(description, public, host = NULL, env_pat = NULL) {
 
-  # arguments used for GitHub Enterprise (GHE)
-  # host:    GHE api endpoint, e.g. "https://github.acme.com/api/v3"
-  #          (handled in ghbase)
-  # env_pat: name of environment variable to find PAT for GHE 
-  #          (handled in gist_auth)
-  
+  # arguments used for GitHub Enterprise
+  # host:      api endpoint, e.g. "https://github.acme.com/api/v3"
+  #            (set in ghbase)
+  # env_pat:   environment variable for PAT, e.g. "GITHUB_ACME_PAT"
+  #            (set in gist_auth)
   host <- ghbase(host)
 
   res <- httr::POST(paste0(host, '/gists'), 

--- a/R/gist_create_git.R
+++ b/R/gist_create_git.R
@@ -150,14 +150,12 @@ gist_create_git <- function(files = NULL, description = "", public = TRUE,
   # host:      api endpoint, e.g. "https://github.acme.com/api/v3"
   #            (set eventually in ghbase)
   # env_user:  environment variable for username, e.g. "GITHUB_ACME_USER" 
-  #            (set here)
   # env_pat:   environment variable for PAT, e.g. "GITHUB_ACME_PAT"
-  #            (set here)
   # gist_host: name of host, e.g, "https://gist.github.acme.com"
-  #            (set here)
   env_user <- env_user %||% "GITHUB_USERNAME"
   env_pat <- env_pat %||% "GITHUB_PAT"
   
+  # set gist_host
   if (is.null(gist_host)) {
     if (identical(ghbase(host), ghbase())) {
       # using github.com

--- a/R/gist_create_git.R
+++ b/R/gist_create_git.R
@@ -307,7 +307,7 @@ cgist <- function(description, public, host = NULL, env_pat = NULL) {
   
   auth <- gist_auth(env_pat = env_pat)
   
-  res <- httr::POST(paste0(url_api, '/gists'), 
+  res <- httr::POST(paste0(host, '/gists'), 
                     auth, 
                     encode = "json",
                     body = jsonlite::toJSON(list(

--- a/R/gist_create_git.R
+++ b/R/gist_create_git.R
@@ -163,8 +163,8 @@ gist_create_git <- function(files = NULL, description = "", public = TRUE,
     } else {
       # use heuristics - extract hostname from url and prepend with "gist."
       hostname <- httr::parse_url(host)$hostname
-      message("Setting `gist_host` to \"", gist_host,"\".")
       gist_host <- paste0("gist.", hostname)
+      message("Setting `gist_host` to \"", gist_host,"\".")
     }
   }
   

--- a/R/gist_create_git.R
+++ b/R/gist_create_git.R
@@ -149,15 +149,22 @@ gist_create_git <- function(files = NULL, description = "", public = TRUE,
   # pick git remote method
   git_method <- match.arg(git_method, c("ssh", "https"))
   
-  # set host
-  if (is.null(host)) {
-    # using github.com
-    host <- ghbase()
-  }
+  # arguments used for GitHub Enterprise (GHE)
+  # host:      GHE api endpoint, e.g. "https://github.acme.com/api/v3"
+  #            (set eventually in ghbase)
+  # env_pat:   name of environment variable to find PAT for GHE 
+  #            (set here)
+  # env_user:  name of environment variable to find username for GHE
+  #            (set here)
+  # gist_host: name of host
+  #            (set here)
+  
+  env_user <- env_user %||% "GITHUB_USERNAME"
+  env_pat <- env_pat %||% "GITHUB_PAT"
   
   # set gist host
   if (is.null(gist_host)) {
-    if (identical(host, ghbase())) {
+    if (identical(ghbase(host), ghbase())) {
       # using github.com
       gist_host <- "gist.github.com"
     } else {
@@ -168,18 +175,6 @@ gist_create_git <- function(files = NULL, description = "", public = TRUE,
     }
   }
   
-  # set env_user
-  if (is.null(env_user)) {
-    # using github.com
-    env_user <- "GITHUB_USERNAME"
-  }
-  
-  # set env_pat
-  if (is.null(env_pat)) {
-    # using github.com
-    env_pat <- "GITHUB_PAT"
-  }
-
   # code handler
   if (!is.null(code)) files <- code_handler(code, filename)
   
@@ -299,12 +294,11 @@ cgist <- function(description, public, host = NULL, env_pat = NULL) {
 
   # arguments used for GitHub Enterprise (GHE)
   # host:    GHE api endpoint, e.g. "https://github.acme.com/api/v3"
+  #          (handled in ghbase)
   # env_pat: name of environment variable to find PAT for GHE 
+  #          (handled in gist_auth)
   
-  if (is.null(host)) {
-    # using github.com
-    host <- ghbase()
-  } 
+  host <- ghbase(host)
 
   res <- httr::POST(paste0(host, '/gists'), 
                     gist_auth(env_pat = env_pat), 

--- a/R/gist_create_git.R
+++ b/R/gist_create_git.R
@@ -171,7 +171,7 @@ gist_create_git <- function(files = NULL, description = "", public = TRUE,
   # set env_user
   if (is.null(env_user)) {
     # using github.com
-    env_pat <- "GITHUB_USERNAME"
+    env_user <- "GITHUB_USERNAME"
   }
   
   # set env_pat
@@ -305,7 +305,7 @@ cgist <- function(description, public, host = NULL, env_pat = NULL) {
     # using github.com
     host <- ghbase()
   } 
-  
+
   res <- httr::POST(paste0(host, '/gists'), 
                     gist_auth(env_pat = env_pat), 
                     encode = "json",

--- a/R/gists.R
+++ b/R/gists.R
@@ -46,8 +46,9 @@ gists <- function(what='public', since=NULL, page=NULL, per_page=30, ...) {
 
 switch_url <- function(x, id, host = NULL){
   
-  # arguments used for GitHub Enterprise (GHE)
-  # host:    GHE api endpoint, e.g. "https://github.acme.com/api/v3"
+  # arguments used for GitHub Enterprise
+  # host:      api endpoint, e.g. "https://github.acme.com/api/v3"
+  #            (set in ghbase)
   host <- ghbase(host)
   
   if (identical(x, "mineall") && is.null(getOption("github.username"))) {

--- a/R/gists.R
+++ b/R/gists.R
@@ -46,7 +46,7 @@ gists <- function(what='public', since=NULL, page=NULL, per_page=30, ...) {
 
 switch_url <- function(x, id, host = NULL){
   
-  # arguments used for GitHub Enterprise
+  # argument used for GitHub Enterprise
   # host:      api endpoint, e.g. "https://github.acme.com/api/v3"
   #            (set in ghbase)
   host <- ghbase(host)

--- a/R/gists.R
+++ b/R/gists.R
@@ -44,17 +44,23 @@ gists <- function(what='public', since=NULL, page=NULL, per_page=30, ...) {
   lapply(res, structure, class = "gist")
 }
 
-switch_url <- function(x, id){
+switch_url <- function(x, id, url_api = NULL){
+  
+  # url_api: accomodates GitHub Enterprise
+  if (is.null(url_api)) {
+    url_api <- ghbase()
+  }
+  
   if (identical(x, "mineall") && is.null(getOption("github.username"))) {
     stop("'github.username' is not set.  Please set using `options(github.username = 'your_github_username')`", call. = FALSE)
   }
   switch(
     x,         
-    public = paste0(ghbase(), '/gists/public'),
-    minepublic = paste0(ghbase(), '/gists'),
-    mineall = sprintf('%s/users/%s/gists', ghbase(), 
+    public = paste0(url_api, '/gists/public'),
+    minepublic = paste0(url_api, '/gists'),
+    mineall = sprintf('%s/users/%s/gists', url_api, 
                       getOption("github.username")),
-    starred = paste0(ghbase(), '/gists/starred'),
-    id = sprintf('%s/gists/%s', ghbase(), id)
+    starred = paste0(url_api, '/gists/starred'),
+    id = sprintf('%s/gists/%s', url_api, id)
   )
 }

--- a/R/gists.R
+++ b/R/gists.R
@@ -44,11 +44,11 @@ gists <- function(what='public', since=NULL, page=NULL, per_page=30, ...) {
   lapply(res, structure, class = "gist")
 }
 
-switch_url <- function(x, id, url_api = NULL){
+switch_url <- function(x, id, host = NULL){
   
   # url_api: accomodates GitHub Enterprise
-  if (is.null(url_api)) {
-    url_api <- ghbase()
+  if (is.null(host)) {
+    host <- ghbase()
   }
   
   if (identical(x, "mineall") && is.null(getOption("github.username"))) {
@@ -56,11 +56,11 @@ switch_url <- function(x, id, url_api = NULL){
   }
   switch(
     x,         
-    public = paste0(url_api, '/gists/public'),
-    minepublic = paste0(url_api, '/gists'),
-    mineall = sprintf('%s/users/%s/gists', url_api, 
+    public = paste0(host, '/gists/public'),
+    minepublic = paste0(host, '/gists'),
+    mineall = sprintf('%s/users/%s/gists', host, 
                       getOption("github.username")),
-    starred = paste0(url_api, '/gists/starred'),
-    id = sprintf('%s/gists/%s', url_api, id)
+    starred = paste0(host, '/gists/starred'),
+    id = sprintf('%s/gists/%s', host, id)
   )
 }

--- a/R/gists.R
+++ b/R/gists.R
@@ -46,11 +46,9 @@ gists <- function(what='public', since=NULL, page=NULL, per_page=30, ...) {
 
 switch_url <- function(x, id, host = NULL){
   
-  # host: accomodates GitHub Enterprise
-  if (is.null(host)) {
-    # uses github.com
-    host <- ghbase()
-  }
+  # arguments used for GitHub Enterprise (GHE)
+  # host:    GHE api endpoint, e.g. "https://github.acme.com/api/v3"
+  host <- ghbase(host)
   
   if (identical(x, "mineall") && is.null(getOption("github.username"))) {
     stop("'github.username' is not set.  Please set using `options(github.username = 'your_github_username')`", call. = FALSE)

--- a/R/gists.R
+++ b/R/gists.R
@@ -46,8 +46,9 @@ gists <- function(what='public', since=NULL, page=NULL, per_page=30, ...) {
 
 switch_url <- function(x, id, host = NULL){
   
-  # url_api: accomodates GitHub Enterprise
+  # host: accomodates GitHub Enterprise
   if (is.null(host)) {
+    # uses github.com
     host <- ghbase()
   }
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,3 +6,6 @@
 #' @export
 #' @usage lhs \%>\% rhs
 NULL
+
+# for use as an internal function
+`%||%` <- rlang::`%||%`

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,7 +7,5 @@
 #' @usage lhs \%>\% rhs
 NULL
 
-# borrows %||% from Hadley
-`%||%` <- function(x, y) {
-  if (is.null(x)) y else x
-}
+# implements from rlang
+`%||%` <- rlang::`%||%`

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,5 +7,7 @@
 #' @usage lhs \%>\% rhs
 NULL
 
-# for use as an internal function
-`%||%` <- rlang::`%||%`
+# borrows %||% from Hadley
+`%||%` <- function(x, y) {
+  if (is.null(x)) y else x
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,5 +7,11 @@
 #' @usage lhs \%>\% rhs
 NULL
 
-# implements from rlang
-`%||%` <- rlang::`%||%`
+# Hadley shorthand to handle nulls with defaults
+`%||%` <- function(x, y) {
+  if (is.null(x)) {
+    y 
+  } else {
+    x
+  }
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -63,8 +63,8 @@ gc <- function(x) {
 }
 
 ghbase <- function(host = NULL) {
-  # argument used for GitHub Enterprise (GHE)
-  # host:    GHE api endpoint, e.g. "https://github.acme.com/api/v3" 
+  # argument used for GitHub Enterprise
+  # host:      api endpoint, e.g. "https://github.acme.com/api/v3"
   host %||% 'https://api.github.com'
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -62,7 +62,11 @@ gc <- function(x) {
   x[rapply(x, length) != 0]
 }
 
-ghbase <- function() 'https://api.github.com'
+ghbase <- function(host = NULL) {
+  # argument used for GitHub Enterprise (GHE)
+  # host:    GHE api endpoint, e.g. "https://github.acme.com/api/v3" 
+  host %||% 'https://api.github.com'
+}
 
 ghead <- function(){
   add_headers(`User-Agent` = "gistr", 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -65,7 +65,18 @@ gc <- function(x) {
 ghbase <- function(host = NULL) {
   # argument used for GitHub Enterprise
   # host:      api endpoint, e.g. "https://github.acme.com/api/v3"
-  host %||% 'https://api.github.com'
+  host <- host %||% 'https://api.github.com'
+  
+  # check that this begins like URL
+  assertthat::assert_that(
+    grepl("https?://", host), 
+    msg = paste(
+      "host:", sQuote(host), "is not a URL.",
+      "Please provide a host that begins with", sQuote("https://")
+    )
+  )
+
+  host
 }
 
 ghead <- function(){

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -69,7 +69,7 @@ ghbase <- function(host = NULL) {
   
   # check that this begins like URL
   assertthat::assert_that(
-    grepl("https?://", host), 
+    grepl("^https?://", host), 
     msg = paste(
       "host:", sQuote(host), "is not a URL.",
       "Please provide a host that begins with", sQuote("https://")

--- a/man/gist.Rd
+++ b/man/gist.Rd
@@ -5,7 +5,7 @@
 \alias{as.gist}
 \title{Get a gist}
 \usage{
-gist(id, revision = NULL, ...)
+gist(id, revision = NULL, url_api = NULL, env_auth = NULL, ...)
 
 as.gist(x)
 }
@@ -13,6 +13,14 @@ as.gist(x)
 \item{id}{(character) A gist id, or a gist URL}
 
 \item{revision}{(character) A sha. optional}
+
+\item{url_api}{(character) Base endpoint for GitHub API, defaults to 
+\code{"https://api.github.com"}. Useful to specify with GitHub Enterprise,
+e.g. \code{"https://github.acme.com/api/v3"}.}
+
+\item{env_auth}{(character) Name of environment variable that contains
+a GitHub PAT (Personal Access Token), defaults to \code{"GITHUB_PAT"}.
+Useful to specify with GitHub Enterprise, e.g. \code{"GITHUB_ACME_PAT"}.}
 
 \item{...}{Curl options passed on to \code{\link[httr]{GET}}}
 

--- a/man/gist.Rd
+++ b/man/gist.Rd
@@ -5,7 +5,7 @@
 \alias{as.gist}
 \title{Get a gist}
 \usage{
-gist(id, revision = NULL, url_api = NULL, env_auth = NULL, ...)
+gist(id, revision = NULL, host = NULL, env_pat = NULL, ...)
 
 as.gist(x)
 }
@@ -14,11 +14,11 @@ as.gist(x)
 
 \item{revision}{(character) A sha. optional}
 
-\item{url_api}{(character) Base endpoint for GitHub API, defaults to 
+\item{host}{(character) Base endpoint for GitHub API, defaults to 
 \code{"https://api.github.com"}. Useful to specify with GitHub Enterprise,
 e.g. \code{"https://github.acme.com/api/v3"}.}
 
-\item{env_auth}{(character) Name of environment variable that contains
+\item{env_pat}{(character) Name of environment variable that contains
 a GitHub PAT (Personal Access Token), defaults to \code{"GITHUB_PAT"}.
 Useful to specify with GitHub Enterprise, e.g. \code{"GITHUB_ACME_PAT"}.}
 

--- a/man/gist_auth.Rd
+++ b/man/gist_auth.Rd
@@ -4,13 +4,17 @@
 \alias{gist_auth}
 \title{Authorize with GitHub.}
 \usage{
-gist_auth(app = gistr_app, reauth = FALSE)
+gist_auth(app = gistr_app, reauth = FALSE, env_pat = NULL)
 }
 \arguments{
 \item{app}{An \code{\link[httr]{oauth_app}} for GitHub. The default uses an 
 application \code{gistr_oauth} created by Scott Chamberlain.}
 
 \item{reauth}{(logical) Force re-authorization?}
+
+\item{env_pat}{(character) Name of environment variable that contains
+a GitHub PAT (Personal Access Token), defaults to \code{"GITHUB_PAT"}.
+Useful to specify with GitHub Enterprise, e.g. \code{"GITHUB_ACME_PAT"}.}
 }
 \description{
 This function is run automatically to allow gistr to access your GitHub 

--- a/man/gist_create_git.Rd
+++ b/man/gist_create_git.Rd
@@ -8,7 +8,8 @@ gist_create_git(files = NULL, description = "", public = TRUE,
   browse = TRUE, knit = FALSE, code = NULL, filename = "code.R",
   knitopts = list(), renderopts = list(), include_source = FALSE,
   artifacts = FALSE, imgur_inject = FALSE, git_method = "ssh",
-  host = NULL, url_api = NULL, env_auth = NULL, sleep = 1, ...)
+  host = NULL, env_user = NULL, env_pat = NULL, gist_host = NULL,
+  sleep = 1, ...)
 }
 \arguments{
 \item{files}{Files to upload. this or \code{code} param must be passed}
@@ -50,17 +51,23 @@ rendered pdf can't be uploaded anyway. Default: FALSE}
 \item{git_method}{(character) One of ssh (default) or https. If a remote 
 already exists, we use that remote, and this parameter is ignored.}
 
-\item{host}{(character) Name of GitHub host, defaults to
-\code{"gist.github.com"}. Useful to specify with GitHub Enterprise,
-e.g. \code{"gist.github.acme.com"}.}
-
-\item{url_api}{(character) Base endpoint for GitHub API, defaults to 
+\item{host}{(character) Base endpoint for GitHub API, defaults to 
 \code{"https://api.github.com"}. Useful to specify with GitHub Enterprise,
 e.g. \code{"https://github.acme.com/api/v3"}.}
 
-\item{env_auth}{(character) Name of environment variable that contains
+\item{env_user}{(character) Name of environment variable that contains
+a GitHub user name, defaults to \code{"GITHUB_USERNAME"}. 
+Useful to specify with GitHub Enterprise, e.g. \code{"GITHUB_ACME_USERNAME"}.
+This is used only if \code{git_method} is \code{"https"}.}
+
+\item{env_pat}{(character) Name of environment variable that contains
 a GitHub PAT (Personal Access Token), defaults to \code{"GITHUB_PAT"}.
 Useful to specify with GitHub Enterprise, e.g. \code{"GITHUB_ACME_PAT"}.}
+
+\item{gist_host}{(character) Name of gist host, uses heuristics with
+\code{host} to default to \code{"gist.github.com"} or 
+\code{"gist.github.acme.com"}. Override if these heuristics do not 
+give the correct result.}
 
 \item{sleep}{(integer) Seconds to sleep after creating gist, but before 
 collecting metadata on the gist. If uploading a lot of stuff, you may want to

--- a/man/gist_create_git.Rd
+++ b/man/gist_create_git.Rd
@@ -8,8 +8,7 @@ gist_create_git(files = NULL, description = "", public = TRUE,
   browse = TRUE, knit = FALSE, code = NULL, filename = "code.R",
   knitopts = list(), renderopts = list(), include_source = FALSE,
   artifacts = FALSE, imgur_inject = FALSE, git_method = "ssh",
-  host = NULL, env_user = NULL, env_pat = NULL, gist_host = NULL,
-  sleep = 1, ...)
+  host = NULL, env_pat = NULL, gist_host = NULL, sleep = 1, ...)
 }
 \arguments{
 \item{files}{Files to upload. this or \code{code} param must be passed}
@@ -54,11 +53,6 @@ already exists, we use that remote, and this parameter is ignored.}
 \item{host}{(character) Base endpoint for GitHub API, defaults to 
 \code{"https://api.github.com"}. Useful to specify with GitHub Enterprise,
 e.g. \code{"https://github.acme.com/api/v3"}.}
-
-\item{env_user}{(character) Name of environment variable that contains
-a GitHub user name, defaults to \code{"GITHUB_USERNAME"}. 
-Useful to specify with GitHub Enterprise, e.g. \code{"GITHUB_ACME_USERNAME"}.
-This is used only if \code{git_method} is \code{"https"}.}
 
 \item{env_pat}{(character) Name of environment variable that contains
 a GitHub PAT (Personal Access Token), defaults to \code{"GITHUB_PAT"}.

--- a/man/gist_create_git.Rd
+++ b/man/gist_create_git.Rd
@@ -8,7 +8,7 @@ gist_create_git(files = NULL, description = "", public = TRUE,
   browse = TRUE, knit = FALSE, code = NULL, filename = "code.R",
   knitopts = list(), renderopts = list(), include_source = FALSE,
   artifacts = FALSE, imgur_inject = FALSE, git_method = "ssh",
-  sleep = 1, ...)
+  host = NULL, url_api = NULL, env_auth = NULL, sleep = 1, ...)
 }
 \arguments{
 \item{files}{Files to upload. this or \code{code} param must be passed}
@@ -49,6 +49,18 @@ rendered pdf can't be uploaded anyway. Default: FALSE}
 
 \item{git_method}{(character) One of ssh (default) or https. If a remote 
 already exists, we use that remote, and this parameter is ignored.}
+
+\item{host}{(character) Name of GitHub host, defaults to
+\code{"gist.github.com"}. Useful to specify with GitHub Enterprise,
+e.g. \code{"gist.github.acme.com"}.}
+
+\item{url_api}{(character) Base endpoint for GitHub API, defaults to 
+\code{"https://api.github.com"}. Useful to specify with GitHub Enterprise,
+e.g. \code{"https://github.acme.com/api/v3"}.}
+
+\item{env_auth}{(character) Name of environment variable that contains
+a GitHub PAT (Personal Access Token), defaults to \code{"GITHUB_PAT"}.
+Useful to specify with GitHub Enterprise, e.g. \code{"GITHUB_ACME_PAT"}.}
 
 \item{sleep}{(integer) Seconds to sleep after creating gist, but before 
 collecting metadata on the gist. If uploading a lot of stuff, you may want to

--- a/tests/testthat/test-ghbase.R
+++ b/tests/testthat/test-ghbase.R
@@ -10,7 +10,7 @@ test_that("ghbase works", {
   
 })
 
-test_that("ghbase errors correctly", {
+test_that("ghbase throws error", {
   
   expect_error(ghbase("github.acme.com"), "not a URL")
   

--- a/tests/testthat/test-ghbase.R
+++ b/tests/testthat/test-ghbase.R
@@ -1,0 +1,17 @@
+context("test-ghbase.R")
+
+test_that("ghbase works", {
+  
+  github <- "https://api.github.com"
+  acme <- "https://github.acme.com/api/v3"
+  
+  expect_identical(ghbase(), github)
+  expect_identical(ghbase(acme), acme)
+  
+})
+
+test_that("ghbase errors correctly", {
+  
+  expect_error(ghbase("github.acme.com"), "not a URL")
+  
+})


### PR DESCRIPTION
## Description

Enables use with GitHub Enterprise

Adds arguments to `gist_create_git()`: `host`, `env_pat`, `gist_host`

Adds arguments to some internal functions:

- `cgist()`: `host`, `env_pat`
- `gist()`: `host`, `env_pat`
- `switch_url()`: `host`
- `ghbase()`: `host`
- `gist_auth()`: `env_pat`

`host` is named to be consistent with the `host` argument in `usethis::use_github()`.

All arguments have NULL defaults, which implies to use values for github.com.

I may have been presumptuous to import **rlang**, so as to be able to use the `%||%` function to handle the NULL arguments. I can do this the long way, if you like.

I also may have been a bit verbose with the comments, but it helped me boil things down to this implementation. I can dial those back, if you like. (Sorry for all the commits, please squash)

## Related Issue

fixes #75 

## Example

Following example 3:

```r
unlink("~/gitgist3", recursive = TRUE)
dir.create("~/gitgist3")
cat("foo bar", file="~/gitgist3/foobar.txt")
cat("hello", file="~/gitgist3/hello.txt")
list.files("~/gitgist3")
```

```r
gistr::gist_create_git("~/gitgist3", host = "https://github.acme.com/api/v3", env_pat = "GITHUB_ACME_PAT")
```

No new tests because they would not be reproducible. I can attest that I ran these examples manually, and they all work (using my company instead of "acme"):

```r
gistr::gist_create_git("~/gitgist3", host = "https://github.acme.com/api/v3", env_pat = "GITHUB_ACME_PAT", git_method = "https")
```

```r
gistr::gist_create_git("~/gitgist3", host = "https://github.acme.com/api/v3", env_pat = "GITHUB_ACME_PAT")
```

```r
gistr::gist_create_git("~/gitgist3",  git_method = "https")
```

```r
gistr::gist_create_git("~/gitgist3")
```