### PR TITLE
use gitcreds for managing github PAT

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -13,11 +13,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
-    permissions:
-      gists: write
-      metadata: read
-      packages: read
-      contents: read
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,6 +44,14 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
+      # Added step for testing gist creation using GIST_TOKEN
+      - name: Run gist creation test
+        env:
+          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
+        run: |
+          echo "Running gist creation test..."
+          Rscript -e "gistr::gist_create(file = 'tests/test-gist.md', description = 'Test gist creation')"
+
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,14 +44,6 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
-      # Added step for testing gist creation using GIST_TOKEN
-      - name: Run gist creation test
-        env:
-          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
-        run: |
-          echo "Running gist creation test..."
-          Rscript -e "gistr::gist_create(file = 'tests/test-gist.md', description = 'Test gist creation')"
-
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,7 +25,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.GIST_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:
@@ -45,12 +45,10 @@ jobs:
           needs: check
 
       # Added step for testing gist creation using GIST_TOKEN
-      - name: Run gist creation test
-        env:
-          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
-        run: |
-          echo "Running gist creation test..."
-          Rscript -e "gistr::gist_create(file = 'tests/test-gist.md', description = 'Test gist creation')"
+      # - name: Run gist creation test
+      #   run: |
+      #     echo "Running gist creation test..."
+      #     Rscript -e "gistr::gist_create(file = 'tests/test-gist.md', description = 'Test gist creation')"
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
-
+    permissions:
+      gists: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -15,6 +15,9 @@ jobs:
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
     permissions:
       gists: write
+      metadata: read
+      packages: read
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,11 +12,11 @@ Description: Work with 'GitHub' 'gists' from 'R' (e.g.,
     <https://gist.github.com/>.
 Version: 0.9.0.93
 Authors@R: c(
-    person("Scott", "Chamberlain", , "myrmecocystus@gmail.com", role = c("aut", "cre"),
+    person("Scott", "Chamberlain", , "myrmecocystus@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1444-9135")),
     person("Ramnath", "Vaidyanathan", role = "aut"),
     person("Karthik", "Ram", role = "aut"),
-    person("Milgram", "Eric", role = "aut"),
+    person("Milgram", "Eric", role = c("aut", "cre")),
     person("Eric R.", "Scott", role = "ctb")
   )
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,12 +12,12 @@ Description: Work with 'GitHub' 'gists' from 'R' (e.g.,
     <https://gist.github.com/>.
 Version: 0.9.0.93
 Authors@R: c(
-    person("Scott", "Chamberlain", role = c("aut", "cre"), 
-        email = "myrmecocystus@gmail.com", 
-        comment = c(ORCID="0000-0003-1444-9135")),
+    person("Scott", "Chamberlain", , "myrmecocystus@gmail.com", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0003-1444-9135")),
     person("Ramnath", "Vaidyanathan", role = "aut"),
     person("Karthik", "Ram", role = "aut"),
-    person("Milgram", "Eric", role = "aut")
+    person("Milgram", "Eric", role = "aut"),
+    person("Eric R.", "Scott", role = "ctb")
   )
 License: MIT + file LICENSE
 URL: https://github.com/ropensci/gistr (devel),
@@ -40,7 +40,7 @@ Imports:
 Suggests:
     git2r,
     testthat
-RoxygenNote: 7.1.1
+RoxygenNote: 7.3.2
 X-schema.org-applicationCategory: Web
 X-schema.org-keywords: http, https, API, web-services, GitHub, GitHub API, gist, gists, code, script, snippet
 X-schema.org-isPartOf: https://ropensci.org

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,8 @@ Imports:
     assertthat,
     knitr,
     rmarkdown,
-    dplyr
+    dplyr,
+    gitcreds
 Suggests:
     git2r,
     testthat

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 gistr in development
 ===============
 
+### NEW FEATURES
+
+* `gistr` now uses `gitcreds` to discover GitHub PATs and now recommends you store your PAT using `gitcreds::gitcreds_set()` rather than as the `GITHUB_PAT` environment variable (although this still works).
+
 ### BUG FIXES
 
 * fix `gist_auth()`: at some point `httr::oauth2.0_token` stopped returning the token in the `headers` slot; can't figure out when this change happened; fix is to get the token from a different place in the returned object; changes to `gist_auth()` to access that new path to the token (#83)

--- a/R/gist_auth.R
+++ b/R/gist_auth.R
@@ -5,15 +5,15 @@
 #'
 #' There are two ways to authorise gistr to work with your GitHub account:
 #'
-#' - Generate a personal access token with the gist scope selected, and set it
-#' as the `GITHUB_PAT` environment variable per session using `Sys.setenv`
-#' or across sessions by adding it to your `.Renviron` file or similar.
-#' See
+#' - Generate a personal access token with the gist scope selected, and store it
+#' with `gitcreds::gitcreds_set()`. Alternatively you can set it as the
+#' `GITHUB_PAT` environment variable per session using `Sys.setenv()` or across
+#' sessions by adding it to your `.Renviron` file or similar. See
 #' https://help.github.com/articles/creating-an-access-token-for-command-line-use
-#' for help
-#' - Interactively login into your GitHub account and authorise with OAuth.
+#' for help or use `usethis::create_github_token()`.
+#' - Interactively log in into your GitHub account and authorise with OAuth.
 #'
-#' Using `GITHUB_PAT` is recommended.
+#' Using `gitcreds::gitcreds_set()` is recommended.
 #'
 #' @export
 #' @param app An [httr::oauth_app()] for GitHub. The default uses an

--- a/R/gistr-package.R
+++ b/R/gistr-package.R
@@ -22,13 +22,12 @@
 #' @importFrom jsonlite fromJSON flatten
 #' @name gistr-package
 #' @aliases gistr
-#' @docType package
 #' @title R client for GitHub gists
 #' @author Scott Chamberlain \email{myrmecocystus@@gmail.com}
 #' @author Ramnath Vaidyanathan \email{ramnath.vaidya@@gmail.com}
 #' @author Karthik Ram \email{karthik.ram@@gmail.com}
 #' @keywords package
-NULL
+"_PACKAGE"
 
 #' @title Create gists
 #'
@@ -43,7 +42,7 @@ NULL
 #' - [gist_create_git()] - Create gists from files or code
 #'  blocks, using  git. Because this function uses git, you have more
 #'  flexibility than with the above function: you can include any binary files,
-#'  and can easily upload all artifacts. 
+#'  and can easily upload all artifacts.
 #' - [gist_create_obj()] - Create gists from R objects: data.frame, list,
 #'  character string, matrix, or numeric. Uses the GitHub HTTP API.
 #'

--- a/man/gist_auth.Rd
+++ b/man/gist_auth.Rd
@@ -24,16 +24,16 @@ account.
 \details{
 There are two ways to authorise gistr to work with your GitHub account:
 \itemize{
-\item Generate a personal access token with the gist scope selected, and set it
-as the \code{GITHUB_PAT} environment variable per session using \code{Sys.setenv}
-or across sessions by adding it to your \code{.Renviron} file or similar.
-See
+\item Generate a personal access token with the gist scope selected, and store it
+with \code{gitcreds::gitcreds_set()}. Alternatively you can set it as the
+\code{GITHUB_PAT} environment variable per session using \code{Sys.setenv()} or across
+sessions by adding it to your \code{.Renviron} file or similar. See
 https://help.github.com/articles/creating-an-access-token-for-command-line-use
-for help
-\item Interactively login into your GitHub account and authorise with OAuth.
+for help or use \code{usethis::create_github_token()}.
+\item Interactively log in into your GitHub account and authorise with OAuth.
 }
 
-Using \code{GITHUB_PAT} is recommended.
+Using \code{gitcreds::gitcreds_set()} is recommended.
 }
 \examples{
 \dontrun{

--- a/man/gistr-package.Rd
+++ b/man/gistr-package.Rd
@@ -22,6 +22,15 @@ and record it in the \code{GITHUB_PAT} envar.
 
 Using the \code{GITHUB_PAT} is recommended.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/ropensci/gistr (devel)}
+  \item \url{https://docs.ropensci.org/gistr (website)}
+  \item Report bugs at \url{https://github.com/ropensci/gistr/issues}
+}
+
+}
 \author{
 Scott Chamberlain \email{myrmecocystus@gmail.com}
 

--- a/tests/testthat/.gitignore
+++ b/tests/testthat/.gitignore
@@ -1,0 +1,1 @@
+.httr-oauth

--- a/tests/testthat/test-gist_auth.R
+++ b/tests/testthat/test-gist_auth.R
@@ -1,3 +1,8 @@
+test_that("gitcreds finds PAT", {
+  expect_equal(gitcreds::gitcreds_get()$password, Sys.getenv("GITHUB_PAT"))
+})
+
+
 test_that("gist_auth finds PAT", {
   skip_on_cran()
   auth <- gist_auth(reauth = TRUE)

--- a/tests/testthat/test-gist_auth.R
+++ b/tests/testthat/test-gist_auth.R
@@ -1,0 +1,16 @@
+test_that("gist_auth finds PAT", {
+  skip_on_cran()
+  auth <- gist_auth(reauth = TRUE)
+  expect_equal(
+    auth$Authorization,
+    paste0("token ", gitcreds::gitcreds_get()$password)
+  )
+})
+
+#can't (easily) test PAT stored with gitcreds::gitcreds_set() or interactive oauth
+
+test_that("valid_gh_pat() works", {
+  expect_false(valid_gh_pat("hello"))
+  expect_false(valid_gh_pat(""))
+  expect_false(valid_gh_pat(NULL))
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Still a WIP, but this PR aims to re-write the `gist_auth()` function to take advantage of `gitcreds::gitcreds_get()` which finds github PATs stored either in the `GITHUB_PAT` env var or stored with `gitcreds::gitcreds_set()`

Changes:
- [x] Update function documentation
- [x] Add tests (these rely on an env var existing, so might not work locally, but should work on GitHub)
- [x] Add my name as a contributor to DESCRIPTION (if that's ok)
- [x] Updates NEWS.md

Would be nice:
- [ ] Have `gist_auth()` check that the PAT has gist scope
 
## Related Issue
closes #95 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
